### PR TITLE
Bump runtime-version to 40

### DIFF
--- a/io.github.mmstick.FontFinder.json
+++ b/io.github.mmstick.FontFinder.json
@@ -2,7 +2,7 @@
   "id": "io.github.mmstick.FontFinder",
   "branch": "stable",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "40",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
GNOME runtime 3.36 is no longer supported as of February 13, 2021